### PR TITLE
Implement BCT NFT view toggle in settings

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -558,9 +558,15 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel)
         {
             // be aware of the tray icon disable state change reported by the OptionsModel object.
             connect(optionsModel,SIGNAL(hideTrayIconChanged(bool)),this,SLOT(setTrayIconVisible(bool)));
+            
+            // be aware of the BCT view show/hide state change reported by the OptionsModel object.
+            connect(optionsModel,SIGNAL(showBCTViewChanged(bool)),this,SLOT(setBCTViewVisible(bool)));
         
             // initialize the disable state of the tray icon with the current value in the model.
             setTrayIconVisible(optionsModel->getHideTrayIcon());
+            
+            // initialize the BCT view visibility with the current value in the model.
+            setBCTViewVisible(optionsModel->getShowBCTView());
         }
     } else {
         // Disable possibility to show main window via action
@@ -624,6 +630,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
     hiveAction->setEnabled(enabled);                // Cascoin: Hive page
+    beeNFTAction->setEnabled(enabled);              // Cascoin: Bee NFT page
     importPrivateKeyAction->setEnabled(enabled);    // Cascoin: Key import helper
 }
 
@@ -750,8 +757,14 @@ void BitcoinGUI::gotoHivePage()
 
 void BitcoinGUI::gotoBeeNFTPage()
 {
-    beeNFTAction->setChecked(true);
-    if (walletFrame) walletFrame->gotoBeeNFTPage();
+    // Only navigate to BCT page if it's enabled in settings
+    if (clientModel && clientModel->getOptionsModel() && clientModel->getOptionsModel()->getShowBCTView()) {
+        beeNFTAction->setChecked(true);
+        if (walletFrame) walletFrame->gotoBeeNFTPage();
+    } else {
+        // If BCT view is disabled, go to overview page instead
+        gotoOverviewPage();
+    }
 }
 
 void BitcoinGUI::gotoHistoryPage()
@@ -1225,6 +1238,14 @@ void BitcoinGUI::setTrayIconVisible(bool fHideTrayIcon)
     if (trayIcon)
     {
         trayIcon->setVisible(!fHideTrayIcon);
+    }
+}
+
+void BitcoinGUI::setBCTViewVisible(bool fShowBCTView)
+{
+    if (beeNFTAction)
+    {
+        beeNFTAction->setVisible(fShowBCTView);
     }
 }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -250,6 +250,9 @@ private Q_SLOTS:
     /** When hideTrayIcon setting is changed in OptionsModel hide or show the icon accordingly. */
     void setTrayIconVisible(bool);
 
+    /** When showBCTView setting is changed in OptionsModel show or hide the BCT tab accordingly. */
+    void setBCTViewVisible(bool);
+
     /** Toggle networking */
     void toggleNetworkActive();
 

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -751,28 +751,55 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_Hive_4">
-         <item>
-          <widget class="QCheckBox" name="hiveContribCF">
-           <property name="text">
-            <string>Send 15% of mouse fee to Community Fund (10% before Labyrinth 1.2 activation)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
+                   <item>
+           <widget class="QCheckBox" name="hiveContribCF">
+            <property name="text">
+             <string>Send 15% of mouse fee to Community Fund (10% before Labyrinth 1.2 activation)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_1_BCT">
+          <item>
+           <widget class="QCheckBox" name="showBCTView">
+            <property name="toolTip">
+             <string>Show or hide the BCT NFT view tab. This is a beta feature that may take time to adapt to the network.</string>
+            </property>
+            <property name="text">
+             <string>Show &amp;BCT NFT View (Beta)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
        <item>
         <widget class="QLabel" name="label_5">
          <property name="text">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -190,6 +190,9 @@ void OptionsDialog::setMapper()
 
     // Cascoin: MinotaurX+Hive1.2
     mapper->addMapping(ui->hiveContribCF, OptionsModel::HiveContribCF);
+    
+    // Cascoin: BCT view toggle
+    mapper->addMapping(ui->showBCTView, OptionsModel::ShowBCTView);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -133,6 +133,11 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fHiveContribCF"))
         settings.setValue("fHiveContribCF", DEFAULT_HIVE_CONTRIB_CF);
     fHiveContribCF = settings.value("fHiveContribCF").toBool();
+
+    // Cascoin: BCT view toggle - default to enabled for existing users
+    if (!settings.contains("fShowBCTView"))
+        settings.setValue("fShowBCTView", true);
+    fShowBCTView = settings.value("fShowBCTView").toBool();
 #endif
 
     // Network
@@ -305,6 +310,10 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         // Cascoin: MinotaurX+Hive1.2
         case HiveContribCF:
             return settings.value("fHiveContribCF");
+
+        // Cascoin: BCT view toggle
+        case ShowBCTView:
+            return fShowBCTView;
 #endif
         case DisplayUnit:
             return nDisplayUnit;
@@ -445,6 +454,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fHiveContribCF = value.toBool();
             if (settings.value("fHiveContribCF") != value)
                 settings.setValue("fHiveContribCF", fHiveContribCF);
+            break;
+
+        // Cascoin: BCT view toggle
+        case ShowBCTView:
+            fShowBCTView = value.toBool();
+            settings.setValue("fShowBCTView", fShowBCTView);
+            Q_EMIT showBCTViewChanged(fShowBCTView);
             break;
 #endif
         case DisplayUnit:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -53,6 +53,7 @@ public:
         HiveCheckThreads,       // Cascoin: Hive: Mining optimisations (int)
         HiveCheckEarlyOut,      // Cascoin: Hive: Mining optimisations (bool)
         HiveContribCF,          // Cascoin: MinotaurX+Hive1.2
+        ShowBCTView,            // Cascoin: Show/hide BCT NFT view (bool)
         OptionIDRowCount,
     };
 
@@ -75,6 +76,7 @@ public:
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
     bool getHiveContribCF() const { return fHiveContribCF; }    // Cascoin: MinotaurX+Hive1.2
+    bool getShowBCTView() const { return fShowBCTView; }       // Cascoin: BCT view toggle
 
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);
@@ -86,6 +88,7 @@ private:
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     bool fHiveContribCF;    // Cascoin: MinotaurX+Hive1.2
+    bool fShowBCTView;      // Cascoin: BCT view toggle
 
     QString language;
     int nDisplayUnit;
@@ -103,6 +106,7 @@ Q_SIGNALS:
     void displayUnitChanged(int unit);
     void coinControlFeaturesChanged(bool);
     void hideTrayIconChanged(bool);
+    void showBCTViewChanged(bool);  // Cascoin: BCT view toggle signal
 };
 
 #endif // BITCOIN_QT_OPTIONSMODEL_H


### PR DESCRIPTION
Add a setting to activate and deactivate the BCT NFT view in the options menu.

This allows users to hide the BCT NFT GUI tab, as it is a beta feature and may take time to adapt to the network, without affecting its underlying functionality (Linear issue CAS-6).

---
Linear Issue: [CAS-6](https://linear.app/cascoin/issue/CAS-6/settings-for-activate-and-deactivate-bct-view)

<a href="https://cursor.com/background-agent?bcId=bc-8feea2a3-426d-4a8c-a2c0-91b6f250ab2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8feea2a3-426d-4a8c-a2c0-91b6f250ab2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

