### PR TITLE
Fix windows crosscompile qt plugin error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,49 +478,49 @@ jobs:
         shell: bash
         run: make -j"$(nproc)"
 
-#      - name: Strip Windows binaries (non-fatal) and keep debug symbols
-#        shell: bash
-#        run: |
-#          shopt -s nullglob
-#          bins=(src/*.exe src/qt/*.exe)
-#          for b in "${bins[@]}"; do
-#            if [[ -f "$b" ]]; then
-#              echo "Processing $b"
-#              if command -v ${HOST}-objcopy >/dev/null 2>&1; then
-#                ${HOST}-objcopy --only-keep-debug "$b" "$b".debug || true
-#              fi
-#              if command -v ${HOST}-strip >/dev/null 2>&1; then
-#                ${HOST}-strip --strip-unneeded "$b" || true
-#              fi
-#              if command -v ${HOST}-objcopy >/dev/null 2>&1; then
-#                ${HOST}-objcopy --add-gnu-debuglink="$b".debug "$b" || true
-#              fi
-#            fi
-#          done
+      - name: Strip Windows binaries (non-fatal) and keep debug symbols
+        shell: bash
+        run: |
+          shopt -s nullglob
+          bins=(src/*.exe src/qt/*.exe)
+          for b in "${bins[@]}"; do
+            if [[ -f "$b" ]]; then
+              echo "Processing $b"
+              if command -v ${HOST}-objcopy >/dev/null 2>&1; then
+                ${HOST}-objcopy --only-keep-debug "$b" "$b".debug || true
+              fi
+              if command -v ${HOST}-strip >/dev/null 2>&1; then
+                ${HOST}-strip --strip-unneeded "$b" || true
+              fi
+              if command -v ${HOST}-objcopy >/dev/null 2>&1; then
+                ${HOST}-objcopy --add-gnu-debuglink="$b".debug "$b" || true
+              fi
+            fi
+          done
 
-#      - name: List built Windows binaries
-#        shell: bash
-#        run: |
-#          ls -lah src || true
-#          ls -lah src/qt || true
+      - name: List built Windows binaries
+        shell: bash
+        run: |
+          ls -lah src || true
+          ls -lah src/qt || true
 
-#      - name: Upload Windows artifacts
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cascoin-windows-${{ env.HOST }}-build
-#          path: |
-#            src/*.exe
-#            src/qt/*.exe
-#          if-no-files-found: warn
+      - name: Upload Windows artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cascoin-windows-${{ env.HOST }}-build
+          path: |
+            src/*.exe
+            src/qt/*.exe
+          if-no-files-found: warn
 
-#      - name: Upload Windows debug symbols
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cascoin-windows-${{ env.HOST }}-debug
-#          path: |
-#            src/*.exe.debug
-#            src/qt/*.exe.debug
-#          if-no-files-found: ignore
+      - name: Upload Windows debug symbols
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cascoin-windows-${{ env.HOST }}-debug
+          path: |
+            src/*.exe.debug
+            src/qt/*.exe.debug
+          if-no-files-found: ignore
 

--- a/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
+++ b/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
@@ -44,25 +44,38 @@ qputenv("QT_QPA_PLATFORM", "xcb");
 // On Windows and macOS, let Qt auto-detect the platform
 ```
 
-### 2. Simplified Qt6 Static Plugin Handling
-Removed complex static plugin import logic for Qt6 and let Qt6's improved automatic plugin detection handle it:
+### 2. Fixed Qt6 Static Plugin Imports
+Updated Qt6 to use runtime platform detection instead of build-time macros:
 
 ```cpp
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
-// Qt6 static plugins - let Qt6 auto-detect platform plugins
-// Qt6 has better automatic plugin detection for static builds
-#else
-// Qt5 static plugins (unchanged)
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_WINDOWS)
+// Qt6 static plugins
+#ifdef Q_OS_WIN
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_COCOA)
+#elif defined(Q_OS_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(Q_OS_MACOS)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 #endif
+#else
+// Qt5 static plugins (unchanged)
+// ...
 #endif
+#endif
+```
+
+### 3. Explicit Windows Platform Selection
+Added explicit platform selection for Windows to ensure the correct plugin is used:
+
+```cpp
+#ifdef Q_OS_LINUX
+// Force Qt to use XCB instead of D-Bus on Linux
+qputenv("QT_QPA_PLATFORM", "xcb");
+#elif defined(Q_OS_WIN)
+// On Windows, explicitly set the platform to ensure correct plugin is used
+qputenv("QT_QPA_PLATFORM", "windows");
 #endif
 ```
 

--- a/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
+++ b/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
@@ -25,12 +25,12 @@ if test "x$bitcoin_qt_got_major_vers" = x6; then
   _BITCOIN_QT_IS_STATIC
   if test "x$bitcoin_cv_static_qt" = xyes; then
     AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-    _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
-    AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
     if test "x$TARGET_OS" = xwindows; then
       _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
       AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
     elif test "x$TARGET_OS" = xlinux; then
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
+      AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
       _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
       AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
     elif test "x$TARGET_OS" = xdarwin; then

--- a/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
+++ b/WINDOWS_QT_PLATFORM_PLUGIN_FIX.md
@@ -1,0 +1,120 @@
+# Windows Qt Platform Plugin Fix
+
+## Problem
+When cross-compiling for Windows, the application fails to start with the error:
+```
+This application failed to start because no Qt platform plugin could be initialized. 
+Reinstalling the application may fix this problem. Available platform plugins are: windows.
+```
+
+## Root Cause
+The issue was in the Qt6 static plugin configuration in the build system. For Qt6 builds, the platform-specific plugin imports were not being configured properly:
+
+1. **Qt6 Configuration Gap**: The Qt6 branch in `build-aux/m4/bitcoin_qt.m4` was only defining `QT_STATICPLUGIN` but not setting up platform-specific macros like `QT_QPA_PLATFORM_WINDOWS`.
+
+2. **Inconsistent Plugin Imports**: In `src/qt/bitcoin.cpp`, Qt6 was unconditionally importing `QWindowsIntegrationPlugin`, while Qt5 correctly used conditional imports based on platform macros.
+
+## Solution Applied
+
+### 1. Fixed Qt6 Static Plugin Configuration (`build-aux/m4/bitcoin_qt.m4`)
+Added proper platform-specific plugin detection and linking for Qt6 static builds:
+
+```m4
+if test "x$bitcoin_qt_got_major_vers" = x6; then
+  dnl Qt6: detect static Qt and define QT_STATICPLUGIN so Q_IMPORT_PLUGIN works
+  _BITCOIN_QT_IS_STATIC
+  if test "x$bitcoin_cv_static_qt" = xyes; then
+    AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
+    _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
+    AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
+    if test "x$TARGET_OS" = xwindows; then
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
+      AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
+    elif test "x$TARGET_OS" = xlinux; then
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
+      AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
+    elif test "x$TARGET_OS" = xdarwin; then
+      AX_CHECK_LINK_FLAG([[-framework IOKit]],[QT_LIBS="$QT_LIBS -framework IOKit"],[AC_MSG_ERROR(could not iokit framework)])
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)],[-lqcocoa])
+      AC_DEFINE(QT_QPA_PLATFORM_COCOA, 1, [Define this symbol if the qt platform is cocoa])
+    fi
+  fi
+```
+
+### 2. Fixed Qt6 Plugin Imports (`src/qt/bitcoin.cpp`)
+Made Qt6 plugin imports conditional like Qt5, based on platform detection:
+
+```cpp
+#if defined(QT_STATICPLUGIN)
+#include <QtPlugin>
+#if QT_VERSION >= 0x060000
+// Qt6 static plugins
+#if defined(QT_QPA_PLATFORM_MINIMAL)
+Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
+#endif
+#if defined(QT_QPA_PLATFORM_XCB)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_WINDOWS)
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_COCOA)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+#endif
+#else
+// Qt5 static plugins (unchanged)
+// ...
+#endif
+#endif
+```
+
+## What This Fixes
+
+1. **Proper Platform Detection**: The build system now correctly detects the target platform (Windows) and defines `QT_QPA_PLATFORM_WINDOWS` for Qt6 builds.
+
+2. **Correct Static Plugin Linking**: The Windows platform plugin (`-lqwindows`) is now properly linked into the executable during the static build process.
+
+3. **Conditional Plugin Imports**: The application now only imports the platform plugin that matches the target platform, preventing conflicts.
+
+## How to Apply the Fix
+
+1. **Regenerate Build Configuration**:
+   ```bash
+   cd /path/to/cascoin
+   ./autogen.sh
+   ```
+
+2. **Reconfigure for Windows Cross-Compilation**:
+   ```bash
+   cd depends
+   make HOST=x86_64-w64-mingw32
+   cd ..
+   CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+   ```
+
+3. **Rebuild**:
+   ```bash
+   make clean
+   make
+   ```
+
+## Verification
+
+After applying this fix, the Windows executable should:
+- Have the Qt Windows platform plugin statically linked
+- Start successfully without the "no Qt platform plugin" error
+- Not require any external Qt DLL files or plugin directories
+
+## Technical Details
+
+The error occurred because:
+- Qt6 static builds weren't getting the proper `QT_QPA_PLATFORM_WINDOWS` macro defined
+- Without this macro, the conditional plugin import in `bitcoin.cpp` wasn't working
+- The application had `QT_STATICPLUGIN` defined but wasn't importing the correct platform plugin
+- Qt runtime couldn't find an available platform plugin to initialize the GUI
+
+This fix ensures that for Qt6 Windows cross-compilation:
+1. `QT_STATICPLUGIN` is defined ✓
+2. `QT_QPA_PLATFORM_WINDOWS` is defined ✓  
+3. `QWindowsIntegrationPlugin` is imported ✓
+4. `-lqwindows` is linked ✓
+
+The static plugin is now properly embedded in the executable, eliminating the need for external plugin files.

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -122,6 +122,8 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
         _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
         AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
       elif test "x$TARGET_OS" = xlinux; then
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
+        AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
         _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
         AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
       elif test "x$TARGET_OS" = xdarwin; then

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -118,8 +118,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     _BITCOIN_QT_IS_STATIC
     if test "x$bitcoin_cv_static_qt" = xyes; then
       AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
-      AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
       if test "x$TARGET_OS" = xwindows; then
         _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
         AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -118,19 +118,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     _BITCOIN_QT_IS_STATIC
     if test "x$bitcoin_cv_static_qt" = xyes; then
       AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-      if test "x$TARGET_OS" = xwindows; then
-        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
-        AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
-      elif test "x$TARGET_OS" = xlinux; then
-        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
-        AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
-        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
-        AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
-      elif test "x$TARGET_OS" = xdarwin; then
-        AX_CHECK_LINK_FLAG([[-framework IOKit]],[QT_LIBS="$QT_LIBS -framework IOKit"],[AC_MSG_ERROR(could not iokit framework)])
-        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)],[-lqcocoa])
-        AC_DEFINE(QT_QPA_PLATFORM_COCOA, 1, [Define this symbol if the qt platform is cocoa])
-      fi
     fi
   elif test "x$bitcoin_qt_got_major_vers" = x5; then
     _BITCOIN_QT_IS_STATIC

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -118,6 +118,19 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     _BITCOIN_QT_IS_STATIC
     if test "x$bitcoin_cv_static_qt" = xyes; then
       AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
+      AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])
+      if test "x$TARGET_OS" = xwindows; then
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
+        AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
+      elif test "x$TARGET_OS" = xlinux; then
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
+        AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
+      elif test "x$TARGET_OS" = xdarwin; then
+        AX_CHECK_LINK_FLAG([[-framework IOKit]],[QT_LIBS="$QT_LIBS -framework IOKit"],[AC_MSG_ERROR(could not iokit framework)])
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)],[-lqcocoa])
+        AC_DEFINE(QT_QPA_PLATFORM_COCOA, 1, [Define this symbol if the qt platform is cocoa])
+      fi
     fi
   elif test "x$bitcoin_qt_got_major_vers" = x5; then
     _BITCOIN_QT_IS_STATIC

--- a/configure~
+++ b/configure~
@@ -29237,6 +29237,236 @@ printf "%s\n" "#define QT_STATICPLUGIN 1" >>confdefs.h
 
 printf "%s\n" "#define QT_STATICPLUGIN 1" >>confdefs.h
 
+      if test "x$TARGET_OS" = xwindows; then
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static Qt plugins: -lqwindows" >&5
+printf %s "checking for static Qt plugins: -lqwindows... " >&6; }
+  CHECK_STATIC_PLUGINS_TEMP_LIBS="$LIBS"
+  LIBS="-lqwindows $QT_LIBS $LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #define QT_STATICPLUGIN
+    #include <QtPlugin>
+    Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+int
+main (void)
+{
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; QT_LIBS="-lqwindows $QT_LIBS"
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; };
+  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
+    if test "x$bitcoin_enable_qt" != xno; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Could not resolve: -lqwindows; cascoin-qt frontend will not be built" >&5
+printf "%s\n" "$as_me: WARNING: Could not resolve: -lqwindows; cascoin-qt frontend will not be built" >&2;}
+    fi
+    bitcoin_enable_qt=no
+    bitcoin_enable_qt_test=no
+  else
+    as_fn_error $? "Could not resolve: -lqwindows" "$LINENO" 5
+  fi
+ ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"
+
+
+printf "%s\n" "#define QT_QPA_PLATFORM_WINDOWS 1" >>confdefs.h
+
+      elif test "x$TARGET_OS" = xlinux; then
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static Qt plugins: -lqminimal" >&5
+printf %s "checking for static Qt plugins: -lqminimal... " >&6; }
+  CHECK_STATIC_PLUGINS_TEMP_LIBS="$LIBS"
+  LIBS="-lqminimal $QT_LIBS $LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #define QT_STATICPLUGIN
+    #include <QtPlugin>
+    Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)
+int
+main (void)
+{
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; QT_LIBS="-lqminimal $QT_LIBS"
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; };
+  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
+    if test "x$bitcoin_enable_qt" != xno; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Could not resolve: -lqminimal; cascoin-qt frontend will not be built" >&5
+printf "%s\n" "$as_me: WARNING: Could not resolve: -lqminimal; cascoin-qt frontend will not be built" >&2;}
+    fi
+    bitcoin_enable_qt=no
+    bitcoin_enable_qt_test=no
+  else
+    as_fn_error $? "Could not resolve: -lqminimal" "$LINENO" 5
+  fi
+ ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"
+
+
+printf "%s\n" "#define QT_QPA_PLATFORM_MINIMAL 1" >>confdefs.h
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static Qt plugins: -lqxcb -lxcb-static" >&5
+printf %s "checking for static Qt plugins: -lqxcb -lxcb-static... " >&6; }
+  CHECK_STATIC_PLUGINS_TEMP_LIBS="$LIBS"
+  LIBS="-lqxcb -lxcb-static $QT_LIBS $LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #define QT_STATICPLUGIN
+    #include <QtPlugin>
+    Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+int
+main (void)
+{
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; QT_LIBS="-lqxcb -lxcb-static $QT_LIBS"
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; };
+  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
+    if test "x$bitcoin_enable_qt" != xno; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Could not resolve: -lqxcb -lxcb-static; cascoin-qt frontend will not be built" >&5
+printf "%s\n" "$as_me: WARNING: Could not resolve: -lqxcb -lxcb-static; cascoin-qt frontend will not be built" >&2;}
+    fi
+    bitcoin_enable_qt=no
+    bitcoin_enable_qt_test=no
+  else
+    as_fn_error $? "Could not resolve: -lqxcb -lxcb-static" "$LINENO" 5
+  fi
+ ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"
+
+
+printf "%s\n" "#define QT_QPA_PLATFORM_XCB 1" >>confdefs.h
+
+      elif test "x$TARGET_OS" = xdarwin; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the linker accepts -framework IOKit" >&5
+printf %s "checking whether the linker accepts -framework IOKit... " >&6; }
+if test ${ax_cv_check_ldflags___framework_IOKit+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS  -framework IOKit"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  ax_cv_check_ldflags___framework_IOKit=yes
+else case e in #(
+  e) ax_cv_check_ldflags___framework_IOKit=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_ldflags___framework_IOKit" >&5
+printf "%s\n" "$ax_cv_check_ldflags___framework_IOKit" >&6; }
+if test "x$ax_cv_check_ldflags___framework_IOKit" = xyes
+then :
+  QT_LIBS="$QT_LIBS -framework IOKit"
+else case e in #(
+  e) as_fn_error $? "could not iokit framework" "$LINENO" 5 ;;
+esac
+fi
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static Qt plugins: -lqcocoa" >&5
+printf %s "checking for static Qt plugins: -lqcocoa... " >&6; }
+  CHECK_STATIC_PLUGINS_TEMP_LIBS="$LIBS"
+  LIBS="-lqcocoa $QT_LIBS $LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #define QT_STATICPLUGIN
+    #include <QtPlugin>
+    Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
+int
+main (void)
+{
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }; QT_LIBS="-lqcocoa $QT_LIBS"
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; };
+  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
+    if test "x$bitcoin_enable_qt" != xno; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Could not resolve: -lqcocoa; cascoin-qt frontend will not be built" >&5
+printf "%s\n" "$as_me: WARNING: Could not resolve: -lqcocoa; cascoin-qt frontend will not be built" >&2;}
+    fi
+    bitcoin_enable_qt=no
+    bitcoin_enable_qt_test=no
+  else
+    as_fn_error $? "Could not resolve: -lqcocoa" "$LINENO" 5
+  fi
+ ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"
+
+
+printf "%s\n" "#define QT_QPA_PLATFORM_COCOA 1" >>confdefs.h
+
+      fi
     fi
   elif test "x$bitcoin_qt_got_major_vers" = x5; then
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -59,17 +59,8 @@
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
-// Qt6 static plugins
-#if defined(QT_QPA_PLATFORM_MINIMAL)
-Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
-#endif
-#if defined(QT_QPA_PLATFORM_XCB)
-Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-#elif defined(QT_QPA_PLATFORM_COCOA)
-Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
-#endif
+// Qt6 static plugins - let Qt6 auto-detect platform plugins
+// Qt6 has better automatic plugin detection for static builds
 #else
 // Qt5 static plugins
 #if defined(QT_QPA_PLATFORM_XCB)
@@ -758,8 +749,12 @@ int main(int argc, char *argv[])
     qputenv("QT_QPA_PLATFORMTHEME", "");
     qputenv("DBUS_SESSION_BUS_ADDRESS", "disabled");
     qputenv("QT_DBUS_NO_ACTIVATION", "1");
-    // Force Qt to use fallback instead of D-Bus
+    
+#ifdef Q_OS_LINUX
+    // Force Qt to use XCB instead of D-Bus on Linux
     qputenv("QT_QPA_PLATFORM", "xcb");
+#endif
+    // On Windows and macOS, let Qt auto-detect the platform
     
     BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100 && QT_VERSION < 0x060000

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -59,8 +59,14 @@
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
-// Qt6 static plugins - let Qt6 auto-detect platform plugins
-// Qt6 has better automatic plugin detection for static builds
+// Qt6 static plugins
+#ifdef Q_OS_WIN
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#elif defined(Q_OS_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(Q_OS_MACOS)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+#endif
 #else
 // Qt5 static plugins
 #if defined(QT_QPA_PLATFORM_XCB)
@@ -753,8 +759,11 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_LINUX
     // Force Qt to use XCB instead of D-Bus on Linux
     qputenv("QT_QPA_PLATFORM", "xcb");
+#elif defined(Q_OS_WIN)
+    // On Windows, explicitly set the platform to ensure correct plugin is used
+    qputenv("QT_QPA_PLATFORM", "windows");
 #endif
-    // On Windows and macOS, let Qt auto-detect the platform
+    // On macOS, let Qt auto-detect the platform
     
     BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100 && QT_VERSION < 0x060000

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -60,7 +60,16 @@
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
 // Qt6 static plugins
+#if defined(QT_QPA_PLATFORM_MINIMAL)
+Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
+#endif
+#if defined(QT_QPA_PLATFORM_XCB)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_WINDOWS)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_COCOA)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+#endif
 #else
 // Qt5 static plugins
 #if defined(QT_QPA_PLATFORM_XCB)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -60,9 +60,6 @@
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
 // Qt6 static plugins
-#if defined(QT_QPA_PLATFORM_MINIMAL)
-Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
-#endif
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -60,6 +60,9 @@
 #include <QtPlugin>
 #if QT_VERSION >= 0x060000
 // Qt6 static plugins
+#if defined(QT_QPA_PLATFORM_MINIMAL)
+Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
+#endif
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)


### PR DESCRIPTION
Fix Qt6 static plugin configuration and imports for Windows cross-compilation.

The Qt6 build system was not defining platform-specific macros (like `QT_QPA_PLATFORM_WINDOWS`) for static builds, preventing the `QWindowsIntegrationPlugin` from being correctly imported and linked into the executable. This resulted in the "no Qt platform plugin could be initialized" error on Windows. The fix ensures these macros are defined and the plugin is conditionally imported and linked for the target platform.

---
Linear Issue: [CAS-10](https://linear.app/cascoin/issue/CAS-10/windows-crosscompiling-issue)

<a href="https://cursor.com/background-agent?bcId=bc-11af450c-4bd5-4c12-9aad-c04d8d083d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11af450c-4bd5-4c12-9aad-c04d8d083d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

